### PR TITLE
Turns out hunting assembly also has ...

### DIFF
--- a/Assets/Scripts/ComponentSolvers/Modded/Shims/ExtendedPasswordComponentSolver.cs
+++ b/Assets/Scripts/ComponentSolvers/Modded/Shims/ExtendedPasswordComponentSolver.cs
@@ -29,7 +29,7 @@ public class ExtendedPasswordComponentSolver : ComponentSolver
 
     static ExtendedPasswordComponentSolver()
     {
-        _componentType = ReflectionHelper.FindType("ExtendedPassword");
+        _componentType = ReflectionHelper.FindType("ExtendedPassword", "ExtendedPassword");
         _ProcessCommandMethod = _componentType.GetMethod("ProcessTwitchCommand", BindingFlags.NonPublic | BindingFlags.Instance);
     }
 


### PR DESCRIPTION
... Extended Password Type.  As such, I had to add in the assembly name
explicitly.