### PR TITLE
Camera changes

### DIFF
--- a/TwitchPlaysAssembly/Src/Audio/InterruptMusic.cs
+++ b/TwitchPlaysAssembly/Src/Audio/InterruptMusic.cs
@@ -14,7 +14,6 @@ public class InterruptMusic : MonoBehaviour
 
     private static InterruptMusic _instance = null;
     private static FieldInfo _volumeLevelField = null;
-    private static MethodInfo _setVolumeMethod = null;
     private Dictionary<int, float> _oldVolumes = new Dictionary<int, float>();
 
     static InterruptMusic()

--- a/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/Misc/EnglishTestComponentSolver.cs
+++ b/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/Misc/EnglishTestComponentSolver.cs
@@ -65,7 +65,6 @@ public class EnglishTestComponentSolver : ComponentSolver
     private static Type _componentType = null;
     private static FieldInfo _indexField = null;
 	
-    private FieldInfo _answerField;
     private Component _englishTestCompoent;
     private KMSelectable selectButton;
     private KMSelectable submitButton;

--- a/TwitchPlaysAssembly/Src/Helpers/LogUploader.cs
+++ b/TwitchPlaysAssembly/Src/Helpers/LogUploader.cs
@@ -16,7 +16,7 @@ public class LogUploader : MonoBehaviour
     [HideInInspector]
     public string LOGPREFIX;
 
-    private string output;
+    //private string output;
 
     private OrderedDictionary domainNames = new OrderedDictionary
     {


### PR DESCRIPTION
Found out why the modules lost the ability to be manually interacted with the moment they were interacted with in Twitch plays.  Now it is possible for the host to still interact with every module manually, even when there is a live camera view on the module.