### PR TITLE
close #75

### DIFF
--- a/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/Perky/ListeningComponentSolver.cs
+++ b/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/Perky/ListeningComponentSolver.cs
@@ -49,7 +49,7 @@ public class ListeningComponentSolver : ComponentSolver
 
     protected override IEnumerator RespondToCommandInternal(string inputCommand)
     {
-	    if (inputCommand.EqualsAny("play", "press play"))
+	    if (inputCommand.ToLowerInvariant().EqualsAny("play", "press play"))
 	    {
 		    yield return null;
 		    yield return DoInteractionClick(_play);


### PR DESCRIPTION
"play" and "press play" were case sensitive, however, "press" itself was not.