### PR TITLE
Fix Game of Life bug and add partial Orientation Cube Logging

### DIFF
--- a/TwitchPlaysAssembly/Src/ComponentSolvers/Helpers/ComponentSolverFactory.cs
+++ b/TwitchPlaysAssembly/Src/ComponentSolvers/Helpers/ComponentSolverFactory.cs
@@ -93,6 +93,7 @@ public static class ComponentSolverFactory
 		ModComponentSolverCreatorShims["spwizAdventureGame"] = (bombCommander, bombComponent) => new AdventureGameShim(bombCommander, bombComponent);
 		ModComponentSolverCreatorShims["ExtendedPassword"] = (bombCommander, bombComponent) => new ExtendedPasswordComponentSolver(bombCommander, bombComponent);
 		ModComponentSolverCreatorShims["iceCreamModule"] = (bombCommander, bombComponent) => new IceCreamConfirm(bombCommander, bombComponent);
+		ModComponentSolverCreatorShims["GameOfLifeSimple"] = (bombCommander, bombComponent) => new GameOfLifeShim(bombCommander, bombComponent);
 
 		//Module Information
 		//Information declared here will be used to generate ModuleInformation.json if it doesn't already exist, and will be overwritten by ModuleInformation.json if it does exist.
@@ -230,7 +231,8 @@ public static class ComponentSolverFactory
 		//Shim added in between Twitch Plays and module (This allows overriding a specific command, or for enforcing unsubmittable penalty)
 		ModComponentSolverInformation["ExtendedPassword"] = new ModuleInformation { moduleDisplayName = "Extended Password", moduleScore = 7, DoesTheRightThing = true };
 		ModComponentSolverInformation["iceCreamModule"] = new ModuleInformation { moduleScore = 12, DoesTheRightThing = true };
-		
+		ModComponentSolverInformation["GameOfLifeSimple"] = new ModuleInformation { moduleScore = 12, manualCode = "Game%20of%20Life" };
+
 		//Timwi (includes Perky/Konqi/Eluminate/Mitterdoo modules maintained by Timwi)
 		ModComponentSolverInformation["AdjacentLettersModule"] = new ModuleInformation { moduleScore = 12 };
 		ModComponentSolverInformation["alphabet"] = new ModuleInformation { moduleDisplayName = "Alphabet", moduleScore = 2, DoesTheRightThing = true };
@@ -314,7 +316,6 @@ public static class ComponentSolverFactory
 		ModComponentSolverInformation["fizzBuzzModule"] = new ModuleInformation { moduleScore = 12 };
 		ModComponentSolverInformation["FlagsModule"] = new ModuleInformation { moduleScore = 10 };
 		ModComponentSolverInformation["FontSelect"] = new ModuleInformation { moduleScore = 4 };
-		ModComponentSolverInformation["GameOfLifeSimple"] = new ModuleInformation { moduleScore = 12, manualCode = "Game%20of%20Life" };
 		ModComponentSolverInformation["GameOfLifeCruel"] = new ModuleInformation { moduleScore = 15 };
 		ModComponentSolverInformation["http"] = new ModuleInformation { moduleScore = 5, helpText = "Submit the response with !{0} resp 123." };
 		ModComponentSolverInformation["HumanResourcesModule"] = new ModuleInformation { moduleScore = 9, DoesTheRightThing = true };

--- a/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/Perky/OrientationCubeComponentSolver.cs
+++ b/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/Perky/OrientationCubeComponentSolver.cs
@@ -15,6 +15,7 @@ public class OrientationCubeComponentSolver : ComponentSolver
 		_right = (MonoBehaviour)_rightField.GetValue(bombComponent.GetComponent(_componentType));
 		_ccw = (MonoBehaviour)_ccwField.GetValue(bombComponent.GetComponent(_componentType));
 		_cw = (MonoBehaviour)_cwField.GetValue(bombComponent.GetComponent(_componentType));
+		//virtualAngleEmulator = (float)_virtualField.GetValue(bombComponent.GetComponent(_componentType));
 		modInfo = ComponentSolverFactory.GetModuleInfo(GetModuleType(), "Move the cube with !{0} press cw l set. The buttons are l, r, cw, ccw, set.");
 	}
 
@@ -36,24 +37,29 @@ public class OrientationCubeComponentSolver : ComponentSolver
 		{
 			switch (cmd)
 			{
-				case "left": case "l": buttons.Add(_left); break;
+				case "left": case "l": buttons.Add(_left); interaction.Add("Left rotation"); break;
 
-				case "right": case "r": buttons.Add(_right); break;
+				case "right": case "r": buttons.Add(_right); interaction.Add("Right rotation"); break;
 
 				case "counterclockwise": case "counter-clockwise": case "ccw":
-				case "anticlockwise": case "anti-clockwise": case "acw": buttons.Add(_ccw); break;
+				case "anticlockwise": case "anti-clockwise": case "acw": buttons.Add(_ccw); interaction.Add("Counterclockwise rotation"); break;
 
-				case "clockwise": case "cw": buttons.Add(_cw); break;
+				case "clockwise": case "cw": buttons.Add(_cw); interaction.Add("Clockwise rotation"); break;
 
-				case "set": case "submit":buttons.Add(_submit); break;
+				case "set": case "submit":buttons.Add(_submit); interaction.Add("submit"); break;
 
 				default: yield break;
 			}   //Check for any invalid commands.  Abort entire sequence if any invalid commands are present.
 		}
 
 		yield return "Orientation Cube Solve Attempt";
+		var debugStart = "[Orientation Cube TP#" + ComponentHandle.IDTextMultiDecker.text + "]";
+		Debug.LogFormat("{0} Inputted commands: {1}", debugStart, String.Join(", ", interaction.ToArray()));
+
 		foreach (MonoBehaviour button in buttons)
+		{
 			yield return DoInteractionClick(button);
+		}
 	}
 
 	static OrientationCubeComponentSolver()
@@ -64,6 +70,7 @@ public class OrientationCubeComponentSolver : ComponentSolver
 		_rightField = _componentType.GetField("YawRightButton", BindingFlags.Public | BindingFlags.Instance);
 		_ccwField = _componentType.GetField("RollLeftButton", BindingFlags.Public | BindingFlags.Instance);
 		_cwField = _componentType.GetField("RollRightButton", BindingFlags.Public | BindingFlags.Instance);
+		//_virtualField = _componentType.GetField("virtualViewAngle", BindingFlags.NonPublic | BindingFlags.Instance);
 	}
 
 	private static Type _componentType = null;
@@ -72,10 +79,18 @@ public class OrientationCubeComponentSolver : ComponentSolver
 	private static FieldInfo _rightField = null;
 	private static FieldInfo _ccwField = null;
 	private static FieldInfo _cwField = null;
+	//private static FieldInfo _virtualField = null;
+
+	private List<string> interaction = new List<string>();
+	/*private string[] sides = new string[] { "l", "r", "f", "b", "t", "o" };
+	private Quaternion emulatedView;
+	private bool first = true;
+	private float originalAngle;*/
 
 	private MonoBehaviour _submit = null;
 	private MonoBehaviour _left = null;
 	private MonoBehaviour _right = null;
 	private MonoBehaviour _ccw = null;
 	private MonoBehaviour _cw = null;
+	//private float virtualAngleEmulator;
 }

--- a/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/Shims/GameOfLifeShim.cs
+++ b/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/Shims/GameOfLifeShim.cs
@@ -1,0 +1,24 @@
+﻿using System.Collections;
+using TwitchPlaysAssembly.ComponentSolvers.Modded.Shims;
+
+public class GameOfLifeShim : ComponentSolverShim
+{
+	public GameOfLifeShim(BombCommander bombCommander, BombComponent bombComponent) : base(bombCommander, bombComponent)
+	{
+
+	}
+
+	protected override IEnumerator RespondToCommandInternal(string inputCommand)
+	{
+		var send = base.RespondToCommandInternal(inputCommand);
+		if (!inputCommand.ToLowerInvariant().EqualsAny("submit", "reset"))
+		{
+			var split = inputCommand.Split(' ');
+			foreach (string set in split)
+			{
+				if (set.Length != 2) yield break;
+			}
+		}
+		while (send.MoveNext()) yield return send.Current;
+	}
+}


### PR DESCRIPTION
- Typing !# 4 will no longer cause Game of Life to break. Instead, the input will now be invalid.
- Twitch Plays will now report inputs send in through commands to Orientation Cube in the log. The ID shown in the log will be the same ID used to claim modules in TP. Work has also been included to emulate the virtual view to attempt to get desired movements, but it's proven difficult without recreating the entire module.