### PR TITLE
Fix “!binder select” command

### DIFF
--- a/TwitchPlaysAssembly/Src/Commands/MissionBinderCommands.cs
+++ b/TwitchPlaysAssembly/Src/Commands/MissionBinderCommands.cs
@@ -61,7 +61,7 @@ public static class MissionBinderCommands
 
 	private static IEnumerator SelectOnPage(FloatingHoldable holdable, int index = 0, IList<string> search = null)
 	{
-		if (index > 0 || search != null)
+		if (index > 0 || (search != null && search.Count > 0))
 		{
 			if ((_currentSelectables == null) || (index > _currentSelectables.Length))
 				yield break;


### PR DESCRIPTION
The bug was that if you do something like `!binder select ,`, you get an empty non-null list of search terms.