### PR TITLE
Allow modules to be unclaimable

### DIFF
--- a/TwitchPlaysAssembly/Src/Commands/GameCommands.cs
+++ b/TwitchPlaysAssembly/Src/Commands/GameCommands.cs
@@ -168,7 +168,7 @@ static class GameCommands
 			if (unclaimedModuleIndex >= unclaimedModules.Count)
 			{
 				// Add back any modules that may have been released.	
-				unclaimedModules = TwitchGame.Instance.Modules.Where(h => !h.Claimed && !h.Solved)
+				unclaimedModules = TwitchGame.Instance.Modules.Where(h => h.CanBeClaimed && !h.Claimed && !h.Solved)
 					.Shuffle().ToList();
 				unclaimedModuleIndex = 0;
 			}
@@ -183,7 +183,7 @@ static class GameCommands
 		{
 			// See if there is a valid module at the current index and increment for the next go around.
 			TwitchModule handle = unclaimedModules[unclaimedModuleIndex];
-			if (handle.Claimed || handle.Solved)
+			if (!handle.CanBeClaimed || handle.Claimed || handle.Solved)
 			{
 				unclaimedModules.RemoveAt(unclaimedModuleIndex);
 				i--;

--- a/TwitchPlaysAssembly/Src/ComponentSolvers/Helpers/ComponentSolverFactory.cs
+++ b/TwitchPlaysAssembly/Src/ComponentSolvers/Helpers/ComponentSolverFactory.cs
@@ -173,7 +173,7 @@ public static class ComponentSolverFactory
 		ModComponentSolverInformation["Listening"] = new ModuleInformation { builtIntoTwitchPlays = true, statusLightOverride = true, statusLightLeft = true, statusLightDown = false, moduleDisplayName = "Listening", moduleScore = 4 };
 		ModComponentSolverInformation["OrientationCube"] = new ModuleInformation { builtIntoTwitchPlays = true, moduleDisplayName = "Orientation Cube", moduleScore = 8 };
 		ModComponentSolverInformation["Probing"] = new ModuleInformation { builtIntoTwitchPlays = true, moduleDisplayName = "Probing", moduleScore = 7 };
-		ModComponentSolverInformation["TurnTheKey"] = new ModuleInformation { builtIntoTwitchPlays = true, moduleDisplayName = "Turn The Key", moduleScore = 3, announceModule = true };
+		ModComponentSolverInformation["TurnTheKey"] = new ModuleInformation { builtIntoTwitchPlays = true, moduleDisplayName = "Turn The Key", moduleScore = 3, announceModule = true, unclaimable = true };
 		ModComponentSolverInformation["TurnTheKeyAdvanced"] = new ModuleInformation { builtIntoTwitchPlays = true, moduleDisplayName = "Turn The Keys", moduleScore = 8, announceModule = true };
 
 		//Kaneb
@@ -282,7 +282,7 @@ public static class ComponentSolverFactory
 		ModComponentSolverInformation["flowerPatch"] = new ModuleInformation { moduleScore = 6, DoesTheRightThing = true };
 		ModComponentSolverInformation["jackAttack"] = new ModuleInformation { moduleScore = 8, DoesTheRightThing = true };
 		ModComponentSolverInformation["matchematics"] = new ModuleInformation { moduleScore = 4, DoesTheRightThing = true };
-		ModComponentSolverInformation["timingIsEverything"] = new ModuleInformation { moduleScore = 3, DoesTheRightThing = true, CameraPinningAlwaysAllowed = true, announceModule = true };
+		ModComponentSolverInformation["timingIsEverything"] = new ModuleInformation { moduleScore = 3, DoesTheRightThing = true, CameraPinningAlwaysAllowed = true, announceModule = true, unclaimable = true };
 		ModComponentSolverInformation["weirdAlYankovic"] = new ModuleInformation { moduleScore = 3, DoesTheRightThing = true };
 
 		//CaitSith2
@@ -729,7 +729,7 @@ public static class ComponentSolverFactory
 		ModComponentSolverInformation["SimonSingsModule"] = new ModuleInformation { moduleScore = 14, DoesTheRightThing = true };
 		ModComponentSolverInformation["SimonSpeaksModule"] = new ModuleInformation { moduleScore = 10, DoesTheRightThing = true };
 		ModComponentSolverInformation["SimonSpinsModule"] = new ModuleInformation { moduleScore = 10, DoesTheRightThing = true };
-		ModComponentSolverInformation["SouvenirModule"] = new ModuleInformation { moduleScore = 0, CameraPinningAlwaysAllowed = true, announceModule = true, DoesTheRightThing = true };
+		ModComponentSolverInformation["SouvenirModule"] = new ModuleInformation { moduleScore = 0, CameraPinningAlwaysAllowed = true, announceModule = true, DoesTheRightThing = true, unclaimable = true };
 		ModComponentSolverInformation["SuperlogicModule"] = new ModuleInformation { moduleScore = 9, DoesTheRightThing = true };
 		ModComponentSolverInformation["SymbolCycleModule"] = new ModuleInformation { moduleScore = 9, DoesTheRightThing = true };
 		ModComponentSolverInformation["TennisModule"] = new ModuleInformation { moduleScore = 10, DoesTheRightThing = true };

--- a/TwitchPlaysAssembly/Src/ComponentSolvers/Helpers/ComponentSolverFactory.cs
+++ b/TwitchPlaysAssembly/Src/ComponentSolvers/Helpers/ComponentSolverFactory.cs
@@ -173,7 +173,7 @@ public static class ComponentSolverFactory
 		ModComponentSolverInformation["Listening"] = new ModuleInformation { builtIntoTwitchPlays = true, statusLightOverride = true, statusLightLeft = true, statusLightDown = false, moduleDisplayName = "Listening", moduleScore = 4 };
 		ModComponentSolverInformation["OrientationCube"] = new ModuleInformation { builtIntoTwitchPlays = true, moduleDisplayName = "Orientation Cube", moduleScore = 8 };
 		ModComponentSolverInformation["Probing"] = new ModuleInformation { builtIntoTwitchPlays = true, moduleDisplayName = "Probing", moduleScore = 7 };
-		ModComponentSolverInformation["TurnTheKey"] = new ModuleInformation { builtIntoTwitchPlays = true, moduleDisplayName = "Turn The Key", moduleScore = 3, announceModule = true, unclaimable = true };
+		ModComponentSolverInformation["TurnTheKey"] = new ModuleInformation { builtIntoTwitchPlays = true, moduleDisplayName = "Turn The Key", moduleScore = 3, announceModule = true };
 		ModComponentSolverInformation["TurnTheKeyAdvanced"] = new ModuleInformation { builtIntoTwitchPlays = true, moduleDisplayName = "Turn The Keys", moduleScore = 8, announceModule = true };
 
 		//Kaneb
@@ -282,7 +282,7 @@ public static class ComponentSolverFactory
 		ModComponentSolverInformation["flowerPatch"] = new ModuleInformation { moduleScore = 6, DoesTheRightThing = true };
 		ModComponentSolverInformation["jackAttack"] = new ModuleInformation { moduleScore = 8, DoesTheRightThing = true };
 		ModComponentSolverInformation["matchematics"] = new ModuleInformation { moduleScore = 4, DoesTheRightThing = true };
-		ModComponentSolverInformation["timingIsEverything"] = new ModuleInformation { moduleScore = 3, DoesTheRightThing = true, CameraPinningAlwaysAllowed = true, announceModule = true, unclaimable = true };
+		ModComponentSolverInformation["timingIsEverything"] = new ModuleInformation { moduleScore = 3, DoesTheRightThing = true, CameraPinningAlwaysAllowed = true, announceModule = true };
 		ModComponentSolverInformation["weirdAlYankovic"] = new ModuleInformation { moduleScore = 3, DoesTheRightThing = true };
 
 		//CaitSith2

--- a/TwitchPlaysAssembly/Src/ModuleData.cs
+++ b/TwitchPlaysAssembly/Src/ModuleData.cs
@@ -13,6 +13,7 @@ public class ModuleInformation
 	public float moduleScore = 5;
 	public bool moduleScoreIsDynamic;
 	public bool announceModule;
+	public bool unclaimable;
 
 	public ScoreMethod scoreMethod;
 

--- a/TwitchPlaysAssembly/Src/TwitchGame.cs
+++ b/TwitchPlaysAssembly/Src/TwitchGame.cs
@@ -384,7 +384,7 @@ public class TwitchGame : MonoBehaviour
 		}
 
 		// Set up some stuff for the !unclaimed command.
-		GameCommands.unclaimedModules = Modules.Shuffle().ToList();
+		GameCommands.unclaimedModules = Modules.Where(h => h.CanBeClaimed).Shuffle().ToList();
 		GameCommands.unclaimedModuleIndex = 0;
 
 		while (OtherModes.ZenModeOn)

--- a/TwitchPlaysAssembly/Src/UI/TwitchModule.cs
+++ b/TwitchPlaysAssembly/Src/UI/TwitchModule.cs
@@ -36,6 +36,9 @@ public class TwitchModule : MonoBehaviour
 	public bool Claimed => PlayerName != null;
 
 	[HideInInspector]
+	public bool CanBeClaimed => !(Solver != null && Solver.ModInfo.unclaimable);
+
+	[HideInInspector]
 	public int BombID;
 
 	public bool Solved => BombComponent.IsSolved;
@@ -463,6 +466,9 @@ public class TwitchModule : MonoBehaviour
 
 		if (Solved)
 			return new ClaimResult(false, $"@{userNickName}, module {Code} ({HeaderText}) is already solved.");
+
+		if (!CanBeClaimed)
+			return new ClaimResult(false, $"@{userNickName}, module {Code} ({HeaderText}) cannot be claimed.");
 
 		// Already claimed by the same user
 		if (userNickName.Equals(PlayerName))


### PR DESCRIPTION
Adds a new boolean to ModuleInformation to mark a module as unclaimable; it won't appear on !unclaimed and any attempts to claim it will fail. (!claimall will ignore them, and !# claim will give a "cannot be claimed" error message.) ~~TTK, TiE, and~~ Souv have been set as unclaimable to start out with.

Do note that if a moderator deems it necessary for whatever reason, they can still be assigned to a player with !# assign.