### PR TITLE
Shim Boolean Keypad

### DIFF
--- a/TwitchPlaysAssembly/Src/ComponentSolvers/Helpers/ComponentSolverFactory.cs
+++ b/TwitchPlaysAssembly/Src/ComponentSolvers/Helpers/ComponentSolverFactory.cs
@@ -93,6 +93,7 @@ public static class ComponentSolverFactory
 
 		// SHIMS
 		// These override at least one specific command or formatting, then pass on control to ProcessTwitchCommand in all other cases. (Or in some cases, enforce unsubmittable penalty)
+		ModComponentSolverCreators["BooleanKeypad"] = module => new BooleanKeypadShim(module);
 		ModComponentSolverCreators["Color Generator"] = module => new ColorGeneratorShim(module);
 		ModComponentSolverCreators["ExtendedPassword"] = module => new ExtendedPasswordComponentSolver(module);
 		ModComponentSolverCreators["groceryStore"] = module => new GroceryStoreShim(module);

--- a/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/Shims/BooleanKeypadShim.cs
+++ b/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/Shims/BooleanKeypadShim.cs
@@ -1,0 +1,18 @@
+using System.Collections;
+
+public class BooleanKeypadShim : ComponentSolverShim
+{
+	public BooleanKeypadShim(TwitchModule module)
+		: base(module, "BooleanKeypad")
+	{
+		ModInfo = ComponentSolverFactory.GetModuleInfo(GetModuleType(), "Use '!{0} press 2 4' to press buttons 2 and 4. | Buttons are indexed 1-4 in reading order.");
+	}
+
+	protected override IEnumerator RespondToCommandShimmed(string inputCommand)
+	{
+		inputCommand = inputCommand.ToLowerInvariant().Trim().Replace("press", "solve").Replace("submit", "solve");
+		IEnumerator command = RespondToCommandUnshimmed(inputCommand.ToLowerInvariant().Trim());
+		while (command.MoveNext())
+			yield return command.Current;
+	}
+}

--- a/TwitchPlaysAssembly/TwitchPlaysAssembly.csproj
+++ b/TwitchPlaysAssembly/TwitchPlaysAssembly.csproj
@@ -113,6 +113,7 @@
     <Compile Include="Src\ComponentSolvers\Modded\Royal_Flu%24h\StreetFighterComponentSolver.cs" />
     <Compile Include="Src\ComponentSolvers\Modded\Royal_Flu%24h\HieroglyphicsComponentSolver.cs" />
     <Compile Include="Src\ComponentSolvers\Modded\Shims\GroceryStoreShim.cs" />
+    <Compile Include="Src\ComponentSolvers\Modded\Shims\BooleanKeypadShim.cs" />
     <Compile Include="Src\Helpers\ClaimQueueItem.cs" />
     <Compile Include="Src\Helpers\CommandQueueItem.cs" />
     <Compile Include="Src\Commands\GlobalCommands.cs" />


### PR DESCRIPTION
Allows usage of "!1 press" and "!1 submit" like basically any other Keypad that exists, instead of only "solve" which is one slip-up away from force-solving the module if a mod+ does it.