### PR TITLE
Settings option to hide unknown command messages

### DIFF
--- a/TwitchPlaysAssembly/Src/TwitchPlaySettings.cs
+++ b/TwitchPlaysAssembly/Src/TwitchPlaySettings.cs
@@ -39,6 +39,7 @@ public class TwitchPlaySettingsData
 	public bool EnableLetterCodes = false;
 	public bool AllowSolvingCurrentBombWithCommandsDisabled = true;
 	public int BombLiveMessageDelay = 0;
+	public bool ShowUnrecognizedCommandError = true;
 	public int ClaimCooldownTime = 30;
 	public int ModuleClaimLimit = 2;
 	public float DynamicScorePercentage = 0.5f;

--- a/TwitchPlaysAssembly/Src/TwitchPlaysService.cs
+++ b/TwitchPlaysAssembly/Src/TwitchPlaysService.cs
@@ -364,7 +364,8 @@ public class TwitchPlaysService : MonoBehaviour
 				if (AttemptInvokeCommand(cmd, msg, cmdStr, m, extraObject))
 					return;
 
-		IRCConnection.SendMessage("@{0}, I don’t recognize that command.", msg.UserNickName, !msg.IsWhisper, msg.UserNickName);
+		if (TwitchPlaySettings.data.ShowUnrecognizedCommandError)
+			IRCConnection.SendMessage("@{0}, I don’t recognize that command.", msg.UserNickName, !msg.IsWhisper, msg.UserNickName);
 	}
 
 	private bool AttemptInvokeCommand<TObj>(StaticCommand command, IRCMessage msg, string cmdStr, Match m, TObj extraObject)


### PR DESCRIPTION
If running multiple bots that all expect a "!" prefix, etc.