### PR TITLE
Fixes to Matrix component solver

### DIFF
--- a/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/Royal_Flu$h/TheMatrixComponentSolver.cs
+++ b/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/Royal_Flu$h/TheMatrixComponentSolver.cs
@@ -50,7 +50,6 @@ public class TheMatrixComponentSolver : ComponentSolver
 			yield break;
 		}
 
-		int timeRemaining = (int) timerComponent.TimeRemaining;
 		command = command.Replace("press ", "").Replace("take ", "");
 		KMSelectable correctButton;
 		if (command.StartsWith("blue"))
@@ -73,6 +72,8 @@ public class TheMatrixComponentSolver : ComponentSolver
 		}
 
 		yield return null;
+
+		int timeRemaining = (int) timerComponent.TimeRemaining;
 		while (timeRemaining % 10 != num)
 		{
 			yield return null;


### PR DESCRIPTION
* Enforce limits on integers in commands (flip time must be between 1-60, press time must be between 0-9)
* Jacking into the Matrix can now be cancelled
* Track the timer in the exact same manner the module does, so that '!1 flip for 6' with 6 seconds of safe time does not strike occasionally, and so that flips are handled properly when the timer is moving at more than 1x speed