### PR TITLE
Add time for PPA actions

### DIFF
--- a/TwitchPlaysAssembly/Src/TwitchPlaySettings.cs
+++ b/TwitchPlaysAssembly/Src/TwitchPlaySettings.cs
@@ -68,6 +68,7 @@ public class TwitchPlaySettingsData
 	public int TimeModeMinimumTimeLost = 15;
 	public int TimeModeMinimumTimeGained = 20;
 	public float AwardDropMultiplierOnStrike = 0.80f;
+	public bool TimeModeTimeForActions = true; 
 
 	public bool EnableFactoryZenModeCameraWall = true;
 	public bool EnableFactoryAutomaticNextBomb = true;


### PR DESCRIPTION
The downside of changing some modules to PPA scoring is that they give pitifully low time in Time Mode. This causes (PPA points * multiplier) time to be added to the timer whenever PPA points are awarded, without advancing the multiplier and with no minimum time to add. Though individually it won't add a *lot* of time, it'll add up over the course of a bomb.

This adds the config mode setting 'TimeModeTimeForActions' to enable/disable this behavior as well.