### PR TITLE
Status light/banner position rework

### DIFF
--- a/TwitchPlaysAssembly/Src/Commands/GlobalCommands.cs
+++ b/TwitchPlaysAssembly/Src/Commands/GlobalCommands.cs
@@ -183,14 +183,7 @@ static class GlobalCommands
 						IRCConnection.SendMessage($"Module {moduleName} score: {modules[0].moduleScore}", user, !isWhisper);
 						break;
 					case "statuslight":
-						if (modules[0].statusLightDown && modules[0].statusLightLeft)
-							IRCConnection.SendMessage($"Module {moduleName} status light position: bottom left", user, !isWhisper);
-						else if (modules[0].statusLightDown)
-							IRCConnection.SendMessage($"Module {moduleName} status light position: bottom right", user, !isWhisper);
-						else if (modules[0].statusLightLeft)
-							IRCConnection.SendMessage($"Module {moduleName} status light position: top left", user, !isWhisper);
-						else
-							IRCConnection.SendMessage($"Module {moduleName} status light position: top right", user, !isWhisper);
+						IRCConnection.SendMessage($"Module {moduleName} status light position: {modules[0].statusLightPosition}", user, !isWhisper);
 						break;
 					case "module pin allowed":
 					case "camera pin allowed":
@@ -305,45 +298,32 @@ static class GlobalCommands
 							case "bl":
 							case "bottomleft":
 							case "bottom left":
-								module.statusLightOverride = true;
-								module.statusLightDown = true;
-								module.statusLightLeft = true;
+								module.statusLightPosition = StatusLightPosition.BottomLeft;
 								break;
 							case "br":
 							case "bottomright":
 							case "bottom right":
-								module.statusLightOverride = true;
-								module.statusLightDown = true;
-								module.statusLightLeft = false;
+								module.statusLightPosition = StatusLightPosition.BottomRight;
 								break;
 							case "tr":
 							case "topright":
 							case "top right":
-								module.statusLightOverride = true;
-								module.statusLightDown = false;
-								module.statusLightLeft = false;
+								module.statusLightPosition = StatusLightPosition.TopRight;
 								break;
 							case "tl":
 							case "topleft":
 							case "top left":
-								module.statusLightOverride = true;
-								module.statusLightDown = false;
-								module.statusLightLeft = true;
+								module.statusLightPosition = StatusLightPosition.TopLeft;
+								break;
+							case "c":
+							case "center":
+								module.statusLightPosition = StatusLightPosition.Center;
 								break;
 							default:
-								module.statusLightOverride = false;
-								module.statusLightDown = defaultModule.statusLightDown;
-								module.statusLightLeft = defaultModule.statusLightLeft;
+								module.statusLightPosition = StatusLightPosition.Default;
 								break;
 						}
-						if (module.statusLightDown && module.statusLightLeft)
-							IRCConnection.SendMessage($"Module {moduleName} status light position changed to: Bottom Left", user, !isWhisper);
-						else if (module.statusLightDown)
-							IRCConnection.SendMessage($"Module {moduleName} status light position changed to: Bottom Right", user, !isWhisper);
-						else if (module.statusLightLeft)
-							IRCConnection.SendMessage($"Module {moduleName} status light position changed to: Top Left", user, !isWhisper);
-						else
-							IRCConnection.SendMessage($"Module {moduleName} status light position changed to: Top Right", user, !isWhisper);
+						IRCConnection.SendMessage($"Module {moduleName} status light position changed to: {module.statusLightPosition}", user, !isWhisper);
 						break;
 					case "module pin allowed":
 					case "camera pin allowed":

--- a/TwitchPlaysAssembly/Src/ComponentSolvers/Helpers/ComponentSolverFactory.cs
+++ b/TwitchPlaysAssembly/Src/ComponentSolvers/Helpers/ComponentSolverFactory.cs
@@ -129,9 +129,7 @@ public static class ComponentSolverFactory
 				"helpText": "Cycle the buttons with !{0} cycle. (Cycle presses each button 3 times, in the order of vert1, horiz1, horiz2, vert2, submit.) Submit your answer with !{0} press vert1 horiz1 horiz2 vert2 submit.",
 				"manualCodeOverride": false,
 				"manualCode": null,
-				"statusLightOverride": true,
-				"statusLightLeft": false,
-				"statusLightDown": false,
+				"statusLightPosition": "Default",
 				"validCommandsOverride": false,
 				"validCommands": null,
 				"DoesTheRightThing": true,
@@ -150,11 +148,6 @@ public static class ComponentSolverFactory
 		 * 
 		 * manualCodeOverride - If true, the manual code will not be overwritten by the manual code in the module.
 		 * manualCode - If defined, is used instead of moduleDisplayName to look up the html/pdf manual.
-		 * 
-		 * statusLightOverride - Specifies an override of the ID# position / rotation. (This must be set if you wish to have the ID be anywhere other than
-		 *      Above the status light, or if you wish to rotate the ID / chat box.)
-		 * statusLightLeft - Specifies whether the ID should be on the left side of the module.
-		 * statusLightDown - Specifies whether the ID should be on the bottom side of the module.
 		 * 
 		 * Finally, validCommands, DoesTheRightThing and all of the override flags will only show up in modules not built into Twitch plays.
 		 * validCommandsOverride - Specifies whether the valid regular expression list should not be updated from the module.
@@ -183,7 +176,7 @@ public static class ComponentSolverFactory
 		ModComponentSolverInformation["CrazyTalk"] = new ModuleInformation { builtIntoTwitchPlays = true, moduleDisplayName = "Crazy Talk", moduleScore = 3 };
 		ModComponentSolverInformation["CryptModule"] = new ModuleInformation { builtIntoTwitchPlays = true, moduleDisplayName = "Cryptography", moduleScore = 9 };
 		ModComponentSolverInformation["ForeignExchangeRates"] = new ModuleInformation { builtIntoTwitchPlays = true, moduleDisplayName = "Foreign Exchange Rates", moduleScore = 3 };
-		ModComponentSolverInformation["Listening"] = new ModuleInformation { builtIntoTwitchPlays = true, statusLightOverride = true, statusLightLeft = true, statusLightDown = false, moduleDisplayName = "Listening", moduleScore = 4 };
+		ModComponentSolverInformation["Listening"] = new ModuleInformation { builtIntoTwitchPlays = true, moduleDisplayName = "Listening", moduleScore = 4 };
 		ModComponentSolverInformation["OrientationCube"] = new ModuleInformation { builtIntoTwitchPlays = true, moduleDisplayName = "Orientation Cube", moduleScore = 8 };
 		ModComponentSolverInformation["Probing"] = new ModuleInformation { builtIntoTwitchPlays = true, moduleDisplayName = "Probing", moduleScore = 7 };
 		ModComponentSolverInformation["TurnTheKey"] = new ModuleInformation { builtIntoTwitchPlays = true, moduleDisplayName = "Turn The Key", moduleScore = 3, announceModule = true };
@@ -233,7 +226,7 @@ public static class ComponentSolverFactory
 		ModComponentSolverInformation["JuckAlchemy"] = new ModuleInformation { builtIntoTwitchPlays = true, moduleDisplayName = "Alchemy", moduleScore = 8 };
 		ModComponentSolverInformation["LEGOModule"] = new ModuleInformation { moduleScore = 14, builtIntoTwitchPlays = true };
 		ModComponentSolverInformation["boolMaze"] = new ModuleInformation { moduleScore = 8, builtIntoTwitchPlays = true };
-		ModComponentSolverInformation["MorseWar"] = new ModuleInformation { moduleScore = 6, builtIntoTwitchPlays = true, statusLightDown = true, statusLightLeft = true };
+		ModComponentSolverInformation["MorseWar"] = new ModuleInformation { moduleScore = 6, builtIntoTwitchPlays = true };
 		ModComponentSolverInformation["necronomicon"] = new ModuleInformation { moduleScore = 12, builtIntoTwitchPlays = true };
 
 		//Steel Crate Games (Need these in place even for the Vanilla modules)
@@ -276,8 +269,8 @@ public static class ComponentSolverFactory
 		ModComponentSolverInformation["calendar"] = new ModuleInformation { moduleScore = 6, DoesTheRightThing = true };
 		ModComponentSolverInformation["characterShift"] = new ModuleInformation { moduleScore = 7, DoesTheRightThing = true };
 		ModComponentSolverInformation["complexKeypad"] = new ModuleInformation { moduleScore = 4, DoesTheRightThing = true };
-		ModComponentSolverInformation["doubleColor"] = new ModuleInformation { moduleScore = 2, DoesTheRightThing = true, statusLightOverride = true, statusLightDown = true, statusLightLeft = true };
-		ModComponentSolverInformation["dragonEnergy"] = new ModuleInformation { moduleScore = 13, DoesTheRightThing = true, statusLightOverride = true, statusLightLeft = true, statusLightDown = true };
+		ModComponentSolverInformation["doubleColor"] = new ModuleInformation { moduleScore = 2, DoesTheRightThing = true };
+		ModComponentSolverInformation["dragonEnergy"] = new ModuleInformation { moduleScore = 13, DoesTheRightThing = true };
 		ModComponentSolverInformation["equations"] = new ModuleInformation { moduleScore = 10, DoesTheRightThing = true };
 		ModComponentSolverInformation["insanagrams"] = new ModuleInformation { moduleScore = 7, DoesTheRightThing = true };
 		ModComponentSolverInformation["subways"] = new ModuleInformation { moduleScore = 5, DoesTheRightThing = true };
@@ -391,7 +384,7 @@ public static class ComponentSolverFactory
 		//Flamanis
 		ModComponentSolverInformation["ChessModule"] = new ModuleInformation { moduleScore = 8, helpText = "Cycle the positions with !{0} cycle. Submit the safe spot with !{0} press C2.", DoesTheRightThing = false };
 		ModComponentSolverInformation["Laundry"] = new ModuleInformation { moduleScore = 11, helpText = "Set all of the options with !{0} set all 30C,2 dot,110C,Wet Cleaning. Set just washing with !{0} set wash 40C. Submit with !{0} insert coin. ...pray for that 4 in 2 & lit BOB Kappa", DoesTheRightThing = true };
-		ModComponentSolverInformation["ModuleAgainstHumanity"] = new ModuleInformation { moduleScore = 7, helpText = "Reset the module with !{0} press reset. Move the black card +2 with !{0} move black 2. Move the white card -3 with !{0} move white -3. Submit with !{0} press submit.", statusLightOverride = true, statusLightDown = false, statusLightLeft = false, DoesTheRightThing = true };
+		ModComponentSolverInformation["ModuleAgainstHumanity"] = new ModuleInformation { moduleScore = 7, helpText = "Reset the module with !{0} press reset. Move the black card +2 with !{0} move black 2. Move the white card -3 with !{0} move white -3. Submit with !{0} press submit.", DoesTheRightThing = true };
 
 		//GHXX
 		ModComponentSolverInformation["characterCodes"] = new ModuleInformation { moduleScore = 6, DoesTheRightThing = true };
@@ -753,19 +746,19 @@ public static class ComponentSolverFactory
 		ModComponentSolverInformation["BlackHoleModule"] = new ModuleInformation { moduleScore = 7, DoesTheRightThing = true };
 		ModComponentSolverInformation["BlindAlleyModule"] = new ModuleInformation { moduleScore = 6, DoesTheRightThing = true };
 		ModComponentSolverInformation["BrailleModule"] = new ModuleInformation { moduleScore = 8, DoesTheRightThing = true };
-		ModComponentSolverInformation["BrokenGuitarChordsModule"] = new ModuleInformation { moduleScore = 9, DoesTheRightThing = true, statusLightOverride = true, statusLightLeft = true };
+		ModComponentSolverInformation["BrokenGuitarChordsModule"] = new ModuleInformation { moduleScore = 9, DoesTheRightThing = true };
 		ModComponentSolverInformation["TheBulbModule"] = new ModuleInformation { moduleScore = 5, DoesTheRightThing = true };
 		ModComponentSolverInformation["CaesarCipherModule"] = new ModuleInformation { moduleScore = 3, DoesTheRightThing = true };
 		ModComponentSolverInformation["TheClockModule"] = new ModuleInformation { moduleScore = 6, DoesTheRightThing = true };
 		ModComponentSolverInformation["ColoredSquaresModule"] = new ModuleInformation { moduleScore = 6, DoesTheRightThing = true };
 		ModComponentSolverInformation["ColoredSwitchesModule"] = new ModuleInformation { moduleScore = 9, DoesTheRightThing = true };
 		ModComponentSolverInformation["CoordinatesModule"] = new ModuleInformation { moduleScore = 9, DoesTheRightThing = true };
-		ModComponentSolverInformation["CornersModule"] = new ModuleInformation { moduleScore = 4, DoesTheRightThing = true };
+		ModComponentSolverInformation["CornersModule"] = new ModuleInformation { moduleScore = 4, DoesTheRightThing = true, statusLightPosition = StatusLightPosition.Center };
 		ModComponentSolverInformation["CursedDoubleOhModule"] = new ModuleInformation { moduleScore = 13, DoesTheRightThing = true };
 		ModComponentSolverInformation["DecoloredSquaresModule"] = new ModuleInformation { moduleScore = 9, DoesTheRightThing = true };
 		ModComponentSolverInformation["DiscoloredSquaresModule"] = new ModuleInformation { moduleScore = 10, DoesTheRightThing = true };
 		ModComponentSolverInformation["DividedSquaresModule"] = new ModuleInformation { moduleScore = 6, DoesTheRightThing = true, announceModule = true };
-		ModComponentSolverInformation["DoubleOhModule"] = new ModuleInformation { moduleScore = 6, DoesTheRightThing = true, statusLightOverride = true, statusLightDown = false, statusLightLeft = false };
+		ModComponentSolverInformation["DoubleOhModule"] = new ModuleInformation { moduleScore = 6, DoesTheRightThing = true };
 		ModComponentSolverInformation["FollowTheLeaderModule"] = new ModuleInformation { moduleScore = 10, DoesTheRightThing = true };
 		ModComponentSolverInformation["FriendshipModule"] = new ModuleInformation { moduleScore = 9, DoesTheRightThing = true };
 		ModComponentSolverInformation["GridlockModule"] = new ModuleInformation { moduleScore = 9, DoesTheRightThing = true };
@@ -993,9 +986,7 @@ public static class ComponentSolverFactory
 				moduleScore = info.moduleScore,
 				moduleScoreOverride = false,
 				moduleScoreIsDynamic = info.moduleScoreIsDynamic,
-				statusLightDown = info.statusLightDown,
-				statusLightLeft = info.statusLightLeft,
-				statusLightOverride = false,
+				statusLightPosition = info.statusLightPosition,
 				unclaimedColor = info.unclaimedColor,
 				validCommands = info.validCommands,
 				validCommandsOverride = false
@@ -1003,7 +994,7 @@ public static class ComponentSolverFactory
 		}
 	}
 
-	private static void AddDefaultModuleInformation(string moduleType, string moduleDisplayName, string helpText, string manualCode, bool statusLeft, bool statusBottom, string[] regexList)
+	private static void AddDefaultModuleInformation(string moduleType, string moduleDisplayName, string helpText, string manualCode, string[] regexList)
 	{
 		if (string.IsNullOrEmpty(moduleType)) return;
 		AddDefaultModuleInformation(GetModuleInfo(moduleType));
@@ -1011,8 +1002,6 @@ public static class ComponentSolverFactory
 		info.moduleDisplayName = moduleDisplayName;
 		if (!string.IsNullOrEmpty(helpText)) info.helpText = helpText;
 		if (!string.IsNullOrEmpty(manualCode)) info.manualCode = manualCode;
-		info.statusLightLeft = statusLeft;
-		info.statusLightDown = statusBottom;
 		info.validCommands = regexList;
 	}
 
@@ -1068,21 +1057,13 @@ public static class ComponentSolverFactory
 			info.manualCode = defInfo.manualCode;
 		}
 
-		if (!info.statusLightOverride)
-		{
-			ModuleData.DataHasChanged |= info.statusLightDown != defInfo.statusLightDown;
-			ModuleData.DataHasChanged |= info.statusLightLeft != defInfo.statusLightLeft;
-			info.statusLightDown = defInfo.statusLightDown;
-			info.statusLightLeft = defInfo.statusLightLeft;
-		}
-
 		if (writeData && !info.builtIntoTwitchPlays)
 			ModuleData.WriteDataToFile();
 
 		return ModComponentSolverInformation[moduleType];
 	}
 
-	public static ModuleInformation GetModuleInfo(string moduleType, string helpText, string manualCode = null, bool statusLightLeft = false, bool statusLightBottom = false)
+	public static ModuleInformation GetModuleInfo(string moduleType, string helpText, string manualCode = null)
 	{
 		ModuleInformation info = GetModuleInfo(moduleType, false);
 		ModuleInformation defInfo = GetDefaultInformation(moduleType);
@@ -1098,18 +1079,8 @@ public static class ComponentSolverFactory
 			info.manualCode = manualCode;
 		}
 
-		if (!info.statusLightOverride)
-		{
-			ModuleData.DataHasChanged |= info.statusLightLeft != statusLightLeft;
-			ModuleData.DataHasChanged |= info.statusLightDown != statusLightBottom;
-			info.statusLightLeft = statusLightLeft;
-			info.statusLightDown = statusLightBottom;
-		}
-
 		defInfo.helpText = helpText;
 		defInfo.manualCode = manualCode;
-		defInfo.statusLightLeft = statusLightLeft;
-		defInfo.statusLightDown = statusLightBottom;
 
 		ModuleData.WriteDataToFile();
 
@@ -1142,9 +1113,6 @@ public static class ComponentSolverFactory
 			if (!string.IsNullOrEmpty(info.manualCode) || info.manualCodeOverride)
 				i.manualCode = info.manualCode;
 
-			i.statusLightLeft = info.statusLightLeft;
-			i.statusLightDown = info.statusLightDown;
-
 			i.moduleScore = info.moduleScore;
 			i.moduleScoreIsDynamic = info.moduleScoreIsDynamic;
 			i.announceModule = info.announceModule;
@@ -1153,7 +1121,7 @@ public static class ComponentSolverFactory
 			i.moduleScoreOverride = info.moduleScoreOverride;
 			i.helpTextOverride = info.helpTextOverride;
 			i.manualCodeOverride = info.manualCodeOverride;
-			i.statusLightOverride = info.statusLightOverride;
+			i.statusLightPosition = info.statusLightPosition;
 
 			if (!i.builtIntoTwitchPlays)
 			{
@@ -1283,14 +1251,6 @@ public static class ComponentSolverFactory
 			info.manualCode = manual;
 		}
 
-		if (FindStatusLightPosition(module.BombComponent, out bool statusLeft, out bool statusBottom) && !info.statusLightOverride)
-		{
-			ModuleData.DataHasChanged |= info.statusLightLeft != statusLeft;
-			ModuleData.DataHasChanged |= info.statusLightDown != statusBottom;
-			info.statusLightLeft = statusLeft;
-			info.statusLightDown = statusBottom;
-		}
-
 		if (FindModuleScore(module.BombComponent, commandComponentType, out int score) && !info.moduleScoreOverride)
 		{
 			ModuleData.DataHasChanged |= !score.Equals(info.moduleScore);
@@ -1329,7 +1289,7 @@ public static class ComponentSolverFactory
 		info.moduleDisplayName = displayName;
 		ModuleData.WriteDataToFile();
 
-		AddDefaultModuleInformation(moduleType, displayName, help, manual, statusLeft, statusBottom, regexList);
+		AddDefaultModuleInformation(moduleType, displayName, help, manual, regexList);
 
 		if (commandComponentType == null) return null;
 		ComponentSolverFields componentSolverFields = new ComponentSolverFields
@@ -1397,25 +1357,6 @@ public static class ComponentSolverFactory
 		{
 			DebugHelper.LogException(ex, "Could not log the component types due to an exception:");
 		}
-	}
-
-	private static bool FindStatusLightPosition(Component bombComponent, out bool statusLightLeft, out bool statusLightBottom)
-	{
-		const string statusLightStatus = "Attempting to find the module’s StatusLightParent...";
-		Component component = bombComponent.GetComponentInChildren<StatusLightParent>() ?? (Component) bombComponent.GetComponentInChildren<KMStatusLightParent>();
-		if (component == null)
-		{
-			DebugLog($"{statusLightStatus} Not found.");
-			statusLightLeft = false;
-			statusLightBottom = false;
-			return false;
-		}
-
-		Vector3 position = bombComponent.transform.InverseTransformPoint(component.transform.position);
-		statusLightLeft = (Math.Round(position.x, 5) < 0);
-		statusLightBottom = (Math.Round(position.z, 5) < 0);
-		//DebugLog($"{statusLightStatus} Found in the {(statusLightBottom ? "bottom" : "top")} {(statusLightLeft ? "left" : "right")} corner.");
-		return true;
 	}
 
 	private static bool FindRegexList(Component bombComponent, Type commandComponentType, out string[] validCommands)

--- a/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/Asimir/ThirdBaseComponentSolver.cs
+++ b/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/Asimir/ThirdBaseComponentSolver.cs
@@ -13,7 +13,7 @@ public class ThirdBaseComponentSolver : ComponentSolver
 		object component = module.BombComponent.GetComponent(ComponentType);
 		_buttons = (KMSelectable[]) ButtonsField.GetValue(component);
 		_phrase = (string[]) PhraseField.GetValue(component);
-		ModInfo = ComponentSolverFactory.GetModuleInfo(GetModuleType(), "Press a button with !{0} z0s8. Word must match the button as it would appear if the module was the right way up. Not case sensitive.", null, true, true);
+		ModInfo = ComponentSolverFactory.GetModuleInfo(GetModuleType(), "Press a button with !{0} z0s8. Word must match the button as it would appear if the module was the right way up. Not case sensitive.", null);
 	}
 
 	protected internal override IEnumerator RespondToCommandInternal(string inputCommand)

--- a/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/Mock Army/AnagramsComponentSolver.cs
+++ b/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/Mock Army/AnagramsComponentSolver.cs
@@ -10,7 +10,7 @@ public class AnagramsComponentSolver : ComponentSolver
 	{
 		_buttons = module.BombComponent.GetComponent<KMSelectable>().Children;
 		string modType = GetModuleType();
-		ModInfo = ComponentSolverFactory.GetModuleInfo(modType, "Submit your answer with !{0} submit poodle", null, modType.Equals("AnagramsModule"));
+		ModInfo = ComponentSolverFactory.GetModuleInfo(modType, "Submit your answer with !{0} submit poodle", null);
 	}
 
 	protected internal override IEnumerator RespondToCommandInternal(string inputCommand)

--- a/TwitchPlaysAssembly/Src/ModuleData.cs
+++ b/TwitchPlaysAssembly/Src/ModuleData.cs
@@ -24,9 +24,7 @@ public class ModuleInformation
 	public bool manualCodeOverride;
 	public string manualCode;
 
-	public bool statusLightOverride;
-	public bool statusLightLeft;
-	public bool statusLightDown;
+	public StatusLightPosition statusLightPosition;
 
 	public bool validCommandsOverride;
 	public string[] validCommands;
@@ -59,6 +57,16 @@ public enum ScoreMethod
 	Default,
 	NeedyTime,
 	NeedySolves,
+}
+
+public enum StatusLightPosition
+{
+	Default,
+	TopRight,
+	TopLeft,
+	BottomRight,
+	BottomLeft,
+	Center,
 }
 
 public static class ModuleData


### PR DESCRIPTION
* Merged `statusLightOverride`/`statusLightLeft`/`statusLightDown` into one variable
  * `StatusLightPosition.Default` will autodetect the corner the status light is in
  * `StatusLightPosition.Center` will make the banner show in the center of the module, for modules that have important information on all four corners (e.g., Corners and Hinges).
    `StatusLightPosition.Center` will never be chosen by `StatusLightPosition.Default`, it must be forced
  * All other enum values force the banner into a specific corner
* Contained all code related to detecting the status light and physically placing the banner within one function
* Don't try to rewrite the status light position in moduleInformation.json every time a module shows up