### PR TITLE
Allow bomb to explode in Time or Zen Mode if strikes occur too quickly.

### DIFF
--- a/TwitchPlaysAssembly/Src/ComponentSolvers/ComponentSolver.cs
+++ b/TwitchPlaysAssembly/Src/ComponentSolvers/ComponentSolver.cs
@@ -1121,42 +1121,44 @@ public abstract class ComponentSolver
 			Module.Bomb.StrikeCount = 0;
 		}
 
-		if (OtherModes.TimeModeOn)
-		{
-			float originalMultiplier = OtherModes.GetAdjustedMultiplier();
-			bool multiDropped = OtherModes.DropMultiplier();
-			float multiplier = OtherModes.GetAdjustedMultiplier();
-			string tempMessage;
-			if (multiDropped)
+		if (!Module.Bomb.CheckStrikeRateLimit()) {
+			if (OtherModes.TimeModeOn)
 			{
-				if (Mathf.Abs(originalMultiplier - multiplier) >= 0.1)
-					tempMessage = "Multiplier reduced to " + Math.Round(multiplier, 1) + " and time";
+				float originalMultiplier = OtherModes.GetAdjustedMultiplier();
+				bool multiDropped = OtherModes.DropMultiplier();
+				float multiplier = OtherModes.GetAdjustedMultiplier();
+				string tempMessage;
+				if (multiDropped)
+				{
+					if (Mathf.Abs(originalMultiplier - multiplier) >= 0.1)
+						tempMessage = "Multiplier reduced to " + Math.Round(multiplier, 1) + " and time";
+					else
+						tempMessage = "Time";
+				}
 				else
-					tempMessage = "Time";
-			}
-			else
-				tempMessage =
-					$"Multiplier set at {TwitchPlaySettings.data.TimeModeMinMultiplier}, cannot be further reduced.  Time";
+					tempMessage =
+						$"Multiplier set at {TwitchPlaySettings.data.TimeModeMinMultiplier}, cannot be further reduced.  Time";
 
-			if (Module.Bomb.CurrentTimer < (TwitchPlaySettings.data.TimeModeMinimumTimeLost / TwitchPlaySettings.data.TimeModeTimerStrikePenalty))
-			{
-				Module.Bomb.Bomb.GetTimer().TimeRemaining = Module.Bomb.CurrentTimer - TwitchPlaySettings.data.TimeModeMinimumTimeLost;
-				tempMessage += $" reduced by {TwitchPlaySettings.data.TimeModeMinimumTimeLost} seconds.";
+				if (Module.Bomb.CurrentTimer < (TwitchPlaySettings.data.TimeModeMinimumTimeLost / TwitchPlaySettings.data.TimeModeTimerStrikePenalty))
+				{
+					Module.Bomb.Bomb.GetTimer().TimeRemaining = Module.Bomb.CurrentTimer - TwitchPlaySettings.data.TimeModeMinimumTimeLost;
+					tempMessage += $" reduced by {TwitchPlaySettings.data.TimeModeMinimumTimeLost} seconds.";
+				}
+				else
+				{
+					float timeReducer = Module.Bomb.CurrentTimer * TwitchPlaySettings.data.TimeModeTimerStrikePenalty;
+					double easyText = Math.Round(timeReducer, 1);
+					Module.Bomb.Bomb.GetTimer().TimeRemaining = Module.Bomb.CurrentTimer - timeReducer;
+					tempMessage += $" reduced by {Math.Round(TwitchPlaySettings.data.TimeModeTimerStrikePenalty * 100, 1)}%. ({easyText} seconds)";
+				}
+				messageParts.Add(tempMessage);
+				Module.Bomb.StrikeCount = 0;
+				TwitchGame.ModuleCameras.UpdateStrikes();
 			}
-			else
-			{
-				float timeReducer = Module.Bomb.CurrentTimer * TwitchPlaySettings.data.TimeModeTimerStrikePenalty;
-				double easyText = Math.Round(timeReducer, 1);
-				Module.Bomb.Bomb.GetTimer().TimeRemaining = Module.Bomb.CurrentTimer - timeReducer;
-				tempMessage += $" reduced by {Math.Round(TwitchPlaySettings.data.TimeModeTimerStrikePenalty * 100, 1)}%. ({easyText} seconds)";
-			}
-			messageParts.Add(tempMessage);
-			Module.Bomb.StrikeCount = 0;
-			TwitchGame.ModuleCameras.UpdateStrikes();
+
+			if (OtherModes.ZenModeOn)
+				Module.Bomb.StrikeLimit += strikeCount;
 		}
-
-		if (OtherModes.ZenModeOn)
-			Module.Bomb.StrikeLimit += strikeCount;
 
 		if (!string.IsNullOrEmpty(userNickName))
 		{

--- a/TwitchPlaysAssembly/Src/UI/TwitchBomb.cs
+++ b/TwitchPlaysAssembly/Src/UI/TwitchBomb.cs
@@ -46,6 +46,9 @@ public class TwitchBomb : MonoBehaviour
 	}
 
 	private static bool HeldFrontFace => KTInputManager.Instance.SelectableManager.GetActiveFace() == FaceEnum.Front;
+
+	private float quickStrikeTime;
+	private int quickStrikeCount;
 	#endregion
 
 	#region Unity Lifecycle
@@ -115,6 +118,23 @@ public class TwitchBomb : MonoBehaviour
 	}
 
 	public void CauseVersusExplosion() =>  StartCoroutine(DelayBombExplosionCoroutine(null, "Evil defeated Good", 0.1f));
+
+	internal bool CheckStrikeRateLimit()
+	{
+		bool result;
+		if (Time.time - quickStrikeTime <= 0.6f)
+		{
+			++quickStrikeCount;
+			result = quickStrikeCount >= 20;
+		}
+		else
+		{
+			quickStrikeCount = 0;
+			result = false;
+		}
+		quickStrikeTime = Time.time;
+		return result;
+	}
 
 	#region Private Methods
 	public IEnumerator DelayBombExplosionCoroutine() => DelayBombExplosionCoroutine(TwitchPlaySettings.data.BombDetonateCommand, "Detonate Command", 1.0f);


### PR DESCRIPTION
An issue has been noted and discussed on Discord involving certain modules that try to instantly detonate the bomb under certain conditions. Depending on how this is implemented, it can cause the game to freeze indefinitely in Time or Zen Mode.

Modules that do this include [Answering Questions](https://github.com/Hexicube/KTANE-Hexi-s-Advanced-Modules/blob/master/Assets/Modules/AdvancedVentingGas/AdvancedVentingGas.cs#L166), [Monsplode, Fight!](https://github.com/bcetin/Monsplode/blob/master/Assets/CreaturesModule/Scripts/MonsplodeFightModule.cs#L501), [Lightspeed](https://github.com/RoyalFlush411/lightspeed/blob/master/Assets/lightspeedScript.cs#L1401) and [Lunchtime](https://github.com/nasko222/lunchtime-master/blob/master/Assets/LunchtimeScript.cs#L300).

This commit allows Twitch Plays to detect when a module is striking indefinitely and allows the bomb to explode in this case. This is defined as 20 strikes with no more than 0.6 second in between them. (The threshold is set at 0.6 second so that the loop used by Answering Questions and Lunchtime will trigger it.)