### PR TITLE
Improve the !call command

### DIFF
--- a/TwitchPlaysAssembly/Src/Commands/GameCommands.cs
+++ b/TwitchPlaysAssembly/Src/Commands/GameCommands.cs
@@ -435,14 +435,13 @@ static class GameCommands
 		}
 
 		var _callsNeeded = TwitchGame.Instance.callsNeeded;
-		var _callsTotal = TwitchGame.Instance.callsTotal;
+		var _callsTotal = TwitchGame.Instance.CallingPlayers.Count;
 
 		// Only call if there are enough calls.
 		if (!(_callsTotal + 1 >= _callsNeeded) && !now)
 		{
-			TwitchGame.Instance.callsTotal++;
-			IRCConnection.SendMessageFormat("{0} out of {1} calls needed.", _callsTotal + 1, _callsNeeded);
 			TwitchGame.Instance.CallingPlayers.Add(user);
+			CallCountCommand();
 			return;
 		}
 
@@ -489,8 +488,6 @@ static class GameCommands
 				return;
 			}
 		}
-
-		TwitchGame.Instance.callsTotal = 0;
 		TwitchGame.Instance.CallingPlayers.Clear();
 		TwitchGame.Instance.CommandQueue.Remove(call);
 		TwitchGame.ModuleCameras?.SetNotes();
@@ -532,13 +529,12 @@ static class GameCommands
 		}
 
 		TwitchGame.Instance.callsNeeded = minimum;
-		TwitchGame.Instance.callsTotal = 0;
 		TwitchGame.Instance.CallingPlayers.Clear();
 		IRCConnection.SendMessageFormat("Set minimum calls to {0}.", minimum);
 	}
 
 	[Command(@"call *count")]
-	public static void CallCountCommand(string user) => IRCConnection.SendMessageFormat("{0} out of {1} calls needed.", TwitchGame.Instance.callsTotal, TwitchGame.Instance.callsNeeded);
+	public static void CallCountCommand() => IRCConnection.SendMessageFormat("{0} out of {1} calls needed.", TwitchGame.Instance.CallingPlayers.Count, TwitchGame.Instance.callsNeeded);
 
 	[Command(@"setmultiplier +(\d*\.?\d+)", AccessLevel.Admin, AccessLevel.Admin)]
 	public static void SetMultiplier([Group(1)] float multiplier) => OtherModes.SetMultiplier(multiplier);

--- a/TwitchPlaysAssembly/Src/TwitchGame.cs
+++ b/TwitchPlaysAssembly/Src/TwitchGame.cs
@@ -24,7 +24,6 @@ public class TwitchGame : MonoBehaviour
 	public Dictionary<string, Dictionary<string, double>> LastClaimedModule = new Dictionary<string, Dictionary<string, double>>();
 	public readonly List<CommandQueueItem> CommandQueue = new List<CommandQueueItem>();
 	public int callsNeeded = 1;
-	public int callsTotal = 0;
 	public List<string> CallingPlayers = new List<string>();
 
 #pragma warning disable 169
@@ -85,7 +84,6 @@ public class TwitchGame : MonoBehaviour
 		Leaderboard.Instance.ClearSolo();
 		LogUploader.Instance.Clear();
 		callsNeeded = 1;
-		callsTotal = 0;
 		CallingPlayers.Clear();
 
 		_bombStarted = false;

--- a/TwitchPlaysAssembly/Src/TwitchGame.cs
+++ b/TwitchPlaysAssembly/Src/TwitchGame.cs
@@ -25,6 +25,7 @@ public class TwitchGame : MonoBehaviour
 	public readonly List<CommandQueueItem> CommandQueue = new List<CommandQueueItem>();
 	public int callsNeeded = 1;
 	public int callsTotal = 0;
+	public List<string> CallingPlayers = new List<string>();
 
 #pragma warning disable 169
 	// ReSharper disable once InconsistentNaming
@@ -85,6 +86,7 @@ public class TwitchGame : MonoBehaviour
 		LogUploader.Instance.Clear();
 		callsNeeded = 1;
 		callsTotal = 0;
+		CallingPlayers.Clear();
 
 		_bombStarted = false;
 		ParentService.GetComponent<KMGameInfo>().OnLightsChange += OnLightsChange;


### PR DESCRIPTION
Some improvements to the `!call` command:
- Allow all call commands to be influenced by the `!call set` command.
- Added `!call set` to check the current call count.
- Prevent players from calling two times. 
- Set maximum calls to 20.
- Add a message when all calls are reached when the minimum calls are bigger than 1:  `"Required calls reached, calling <username>: <command>"`
- Another message when `!callnow` is used: `"Bypassing the required number of calls, calling <username>: <command>"`
---
Resolves #469 
Thanks to MrPeanut1028 and sleepin-fang!