### PR TITLE
Player lockout on !call and other various improvements to !call

### DIFF
--- a/TwitchPlaysAssembly/Src/Commands/GameCommands.cs
+++ b/TwitchPlaysAssembly/Src/Commands/GameCommands.cs
@@ -423,89 +423,6 @@ static class GameCommands
 		}
 	}
 
-<<<<<<< HEAD
-    [Command(@"call *set ( +.+)")]
-    public static void CallChangeSet(string user, bool isWhisper, [Group(1)] string calltrySet)
-    {
-        int x;//used for testing purposes, makes sure it can be converted into an int
-        if (Int32.TryParse(calltrySet, out x))
-        {//valid, now check to make sure it woks in this context
-			if (x >= 1)
-            {
-                callSet = x;
-                currentCall = 0;
-                IRCConnection.SendMessage("{0} calls now required for a queued command. Pending calls reset.", callSet);
-            }
-            else IRCConnection.SendMessage($"@{user}, invalid value, no action taken.", user, !isWhisper);
-        }
-		else IRCConnection.SendMessage($"@{user}, invalid value, no action taken.", user, !isWhisper);
-    }
-
-    [Command(@"call(?! *all)(?! *set)( +.+)?")]
-	public static void CallQueuedCommand(string user, bool isWhisper, [Group(1)] string name)
-	{
-        currentCall++;
-        if (currentCall >= callSet) 
-        {
-			if (!(callSet == 1)) IRCConnection.SendMessage("{0} of {1} calls now made, calling command.", currentCall, callSet);
-            name = name?.Trim();
-
-            CommandQueueItem call = null;
-            if (string.IsNullOrEmpty(name))
-            {
-                // Call the first unnamed item in the queue.
-                call = TwitchGame.Instance.CommandQueue.Find(item => item.Name == null);
-
-                if (call == null)
-                {
-                    IRCConnection.SendMessage($"@{user}, no unnamed commands in the queue.", user, !isWhisper);
-                    return;
-                }
-            }
-            else if (name.StartsWith("!"))
-            {
-                name += ' ';
-
-                // Call an unnamed item in the queue for a specific module.
-                call = TwitchGame.Instance.CommandQueue.Find(item => item.Message.Text.StartsWith(name) && item.Name == null);
-
-                if (call == null)
-                {
-                    // If a named command exists, and no unnamed commands exist, then show the name of that command (but don't call it).
-                    call = TwitchGame.Instance.CommandQueue.Find(item => item.Message.Text.StartsWith(name));
-
-                    if (call != null)
-                        IRCConnection.SendMessage($"@{user}, module {name} is queued with the name “{call.Name}”, please use “!call {call.Name}” to call it.", user, !isWhisper);
-                    else
-                        IRCConnection.SendMessage($"@{user}, no commands for module {name} in the queue.", user, !isWhisper);
-
-                    return;
-                }
-            }
-
-            else
-            {
-                // Call a named item in the queue.
-                call = TwitchGame.Instance.CommandQueue.FirstOrDefault(item => name.EqualsIgnoreCase(item.Name));
-
-                if (call == null)
-                {
-                    IRCConnection.SendMessage($"@{user}, no commands named “{name}” in the queue.", user, !isWhisper);
-                    return;
-                }
-            }
-
-            TwitchGame.Instance.CommandQueue.Remove(call);
-            TwitchGame.ModuleCameras?.SetNotes();
-            IRCConnection.SendMessageFormat("Calling {0}: {1}", call.Message.UserNickName, call.Message.Text);
-            IRCConnection.ReceiveMessage(call.Message);
-            currentCall = 0;
-        }
-        else //not met required calls yet
-        {
-            IRCConnection.SendMessage("{0} of {1} calls now made.", currentCall, callSet);
-        }
-=======
 	[Command(@"call( *now)?(?! *all| *set)( +.+)?")]
 	public static void CallQueuedCommand(string user, bool isWhisper, [Group(1)] bool now, [Group(2)] string name)
 	{
@@ -572,7 +489,6 @@ static class GameCommands
 		TwitchGame.ModuleCameras?.SetNotes();
 		IRCConnection.SendMessageFormat("Calling {0}: {1}", call.Message.UserNickName, call.Message.Text);
 		IRCConnection.ReceiveMessage(call.Message);
->>>>>>> fe37f429e33b578a5ff716896a7f4b8c28c7a4d2
 	}
 
 	[Command(@"call *all")]

--- a/TwitchPlaysAssembly/Src/TwitchGame.cs
+++ b/TwitchPlaysAssembly/Src/TwitchGame.cs
@@ -25,6 +25,7 @@ public class TwitchGame : MonoBehaviour
 	public readonly List<CommandQueueItem> CommandQueue = new List<CommandQueueItem>();
 	public int callsNeeded = 1;
 	public int callsTotal = 0;
+    public string[] playersCalled = new string[10];
 
 #pragma warning disable 169
 	// ReSharper disable once InconsistentNaming
@@ -85,6 +86,10 @@ public class TwitchGame : MonoBehaviour
 		LogUploader.Instance.Clear();
 		callsNeeded = 1;
 		callsTotal = 0;
+		for (int i = 0; i<10; i++)
+        {
+            playersCalled[i] = "";
+        }
 
 		_bombStarted = false;
 		ParentService.GetComponent<KMGameInfo>().OnLightsChange += OnLightsChange;

--- a/TwitchPlaysAssembly/Src/TwitchGame.cs
+++ b/TwitchPlaysAssembly/Src/TwitchGame.cs
@@ -23,13 +23,8 @@ public class TwitchGame : MonoBehaviour
 	public readonly Dictionary<int, string> NotesDictionary = new Dictionary<int, string>();
 	public Dictionary<string, Dictionary<string, double>> LastClaimedModule = new Dictionary<string, Dictionary<string, double>>();
 	public readonly List<CommandQueueItem> CommandQueue = new List<CommandQueueItem>();
-<<<<<<< HEAD
-    public int callSet = 1;
-    public int currentCall = 0;
-=======
 	public int callsNeeded = 1;
 	public int callsTotal = 0;
->>>>>>> fe37f429e33b578a5ff716896a7f4b8c28c7a4d2
 
 #pragma warning disable 169
 	// ReSharper disable once InconsistentNaming

--- a/TwitchPlaysAssembly/Src/TwitchGame.cs
+++ b/TwitchPlaysAssembly/Src/TwitchGame.cs
@@ -23,6 +23,8 @@ public class TwitchGame : MonoBehaviour
 	public readonly Dictionary<int, string> NotesDictionary = new Dictionary<int, string>();
 	public Dictionary<string, Dictionary<string, double>> LastClaimedModule = new Dictionary<string, Dictionary<string, double>>();
 	public readonly List<CommandQueueItem> CommandQueue = new List<CommandQueueItem>();
+    public int callSet = 1;
+    public int currentCall = 0;
 
 #pragma warning disable 169
 	// ReSharper disable once InconsistentNaming


### PR DESCRIPTION
1. Any type of `!call` command now counts for the total number of calls
2. Players can now only send one call at a time
3. `!callcount` added to state the number of calls that have been sent
4. `!callplayers` added to see who has already sent `!call`
5. Maximum of 10 callers now set in stone
6. Added some additional lines explaining if / why a command was / was not sent

This adds all of the features in (fixes #469 )