### PR TITLE
Require SuperUser Access for the elevator

### DIFF
--- a/TwitchPlaysAssembly/Src/Commands/GlobalCommands.cs
+++ b/TwitchPlaysAssembly/Src/Commands/GlobalCommands.cs
@@ -768,7 +768,7 @@ static class GlobalCommands
 	[Command(@"silencemode", AccessLevel.SuperUser, AccessLevel.SuperUser)]
 	public static void SilenceMode() => IRCConnection.ToggleSilenceMode();
 
-	[Command(@"elevator")]
+	[Command(@"elevator", AccessLevel.SuperUser, AccessLevel.SuperUser)]
 	public static void Elevator() => TPElevatorSwitch.Instance?.ReportState();
 
 	[Command(@"elevator (on|off|flip|toggle|switch|press|push)")]


### PR DESCRIPTION
Only these people should be allowed to enter a room that can break some modules. 