### PR TITLE
Implement a Findclaim limit

### DIFF
--- a/TwitchPlaysAssembly/Src/TwitchGame.cs
+++ b/TwitchPlaysAssembly/Src/TwitchGame.cs
@@ -25,6 +25,8 @@ public class TwitchGame : MonoBehaviour
 	public readonly List<CommandQueueItem> CommandQueue = new List<CommandQueueItem>();
 	public int callsNeeded = 1;
 	public List<string> CallingPlayers = new List<string>();
+	public int FindClaimUse = 0;
+	public Dictionary<string, int> FindClaimPlayers = new Dictionary<string, int>();
 
 #pragma warning disable 169
 	// ReSharper disable once InconsistentNaming
@@ -85,11 +87,15 @@ public class TwitchGame : MonoBehaviour
 		LogUploader.Instance.Clear();
 		callsNeeded = 1;
 		CallingPlayers.Clear();
+		FindClaimPlayers.Clear();
 
 		_bombStarted = false;
 		ParentService.GetComponent<KMGameInfo>().OnLightsChange += OnLightsChange;
 
 		StartCoroutine(CheckForBomb());
+
+		FindClaimUse = TwitchPlaySettings.data.FindClaimLimit;
+		StartCoroutine(AdjustFindClaimLimit());
 		try
 		{
 			string path = Path.Combine(Application.persistentDataPath, "TwitchPlaysLastClaimed.json");
@@ -586,6 +592,18 @@ public class TwitchGame : MonoBehaviour
 		IRCConnection.SendMessage(message);
 
 		callback?.Invoke();
+	}
+
+	private IEnumerator AdjustFindClaimLimit()
+	{
+		if (TwitchPlaySettings.data.FindClaimAddTime < 1) yield break;
+
+		var _time = TwitchPlaySettings.data.FindClaimAddTime * 60;
+		while (true)
+		{
+			yield return new WaitForSeconds(_time);
+			FindClaimUse++;
+		}
 	}
 
 	private void SendAnalysisLink()

--- a/TwitchPlaysAssembly/Src/TwitchPlaySettings.cs
+++ b/TwitchPlaysAssembly/Src/TwitchPlaySettings.cs
@@ -42,6 +42,9 @@ public class TwitchPlaySettingsData
 	public bool ShowUnrecognizedCommandError = true;
 	public int ClaimCooldownTime = 30;
 	public int ModuleClaimLimit = 2;
+	public int FindClaimLimit = 3;
+	public int FindClaimTerms = 3;
+	public int FindClaimAddTime = 5;
 	public float DynamicScorePercentage = 0.5f;
 	public bool EnableTwitchPlayShims = true;
 	public float UnsubmittablePenaltyPercent = 0.3f;


### PR DESCRIPTION
Users can spam chat with a large `!findclaim` list, and the community asked to have this capped. The lists can no longer be longer than 3 by default (`FindClaimTerms`). This also adds a `!findclaim` limit of 3 by default per bomb and increases by 1 every 5 minutes by default, while this can be adjusted by the streamer. All of these individually can be set to `-1` if the streamer wants to disable the specific features. This will not affect the use of `!findview`. 