### PR TITLE
Fix the use of !callnow

### DIFF
--- a/TwitchPlaysAssembly/Src/Commands/GameCommands.cs
+++ b/TwitchPlaysAssembly/Src/Commands/GameCommands.cs
@@ -562,21 +562,23 @@ static class GameCommands
 	{
 		name = name?.Trim();
 
-		if (TwitchGame.Instance.CallingPlayers.Contains(user))
-		{
-			IRCConnection.SendMessageFormat("@{0}, you already called!", user);
-			return;
-		}
+		if (!now){
+			if (TwitchGame.Instance.CallingPlayers.Contains(user))
+			{
+				IRCConnection.SendMessageFormat("@{0}, you already called!", user);
+				return;
+			}
 
-		var _callsNeeded = TwitchGame.Instance.callsNeeded;
-		var _callsTotal = TwitchGame.Instance.CallingPlayers.Count;
+			var _callsNeeded = TwitchGame.Instance.callsNeeded;
+			var _callsTotal = TwitchGame.Instance.CallingPlayers.Count;
 
-		// Only call if there are enough calls.
-		if (!(_callsTotal + 1 >= _callsNeeded) && !now)
-		{
-			TwitchGame.Instance.CallingPlayers.Add(user);
-			CallCountCommand();
-			return;
+			// Only call if there are enough calls.
+			if (!(_callsTotal + 1 >= _callsNeeded))
+			{
+				TwitchGame.Instance.CallingPlayers.Add(user);
+				CallCountCommand();
+				return;
+			}
 		}
 
 		CommandQueueItem call = null;


### PR DESCRIPTION
If you had already sent `!call` you would not be able to use `!callnow`. I changed this so you now can use `!callnow` after `!call`. Also, I moved this so it just skips the checking of a couple of things if `!callnow` is sent. 