### PR TITLE
Cap Forget Enigma scoring

### DIFF
--- a/TwitchPlaysAssembly/Src/ComponentSolvers/ComponentSolver.cs
+++ b/TwitchPlaysAssembly/Src/ComponentSolvers/ComponentSolver.cs
@@ -684,6 +684,7 @@ public abstract class ComponentSolver
 						break;
 
 					case "HexiEvilFMN": // Forget Everything
+					case "forgetEnigma": // Forget Enigma
 						moduleScore += (int) (Mathf.Clamp(Module.Bomb.bombSolvableModules, 1, 100) * multiplier * TwitchPlaySettings.data.DynamicScorePercentage);
 						break;
 


### PR DESCRIPTION
It generates a max of 100 stages, just like Forget Everything.