### PR TITLE
Art Appreciation component solver

### DIFF
--- a/TwitchPlaysAssembly/Src/Commands/ModuleCommands.cs
+++ b/TwitchPlaysAssembly/Src/Commands/ModuleCommands.cs
@@ -440,8 +440,6 @@ static class ModuleCommands
 				{
 					delay = groups["time"].Value.TryParseInt() ?? groups["stime"].Value.TryParseInt() ?? 2;
 					delay = Math.Max(2, delay);
-					if (delay >= 15)
-						musicPlayer = MusicPlayer.StartRandomMusic();
 				}
 
 				object toYield = command ? (object) RunModuleCommand(module, user, groups["command"].Value) : delay;
@@ -462,12 +460,22 @@ static class ModuleCommands
 					routine = Zoom(module, zoomData, routine ?? toYield);
 				}
 
+				// Art Appreciation special handling...
+				AppreciateArtComponentSolver artSolver = null;
+				if (module.Solver is AppreciateArtComponentSolver && zooming && !tilt)
+					artSolver.ZoomStarted(user);
+				else if (delay >= 15)
+					musicPlayer = MusicPlayer.StartRandomMusic();
+
 				yield return routine;
 				if (CoroutineCanceller.ShouldCancel)
 				{
 					CoroutineCanceller.ResetCancel();
 					IRCConnection.SendMessage($"Sorry @{user}, your request to hold up the bomb for {delay} seconds has been cut short.");
 				}
+
+				if (artSolver != null && zooming && !tilt)
+					artSolver.ZoomEnded();
 
 				if (musicPlayer != null)
 					musicPlayer.StopMusic();

--- a/TwitchPlaysAssembly/Src/ComponentSolvers/ComponentSolver.cs
+++ b/TwitchPlaysAssembly/Src/ComponentSolvers/ComponentSolver.cs
@@ -794,6 +794,11 @@ public abstract class ComponentSolver
 		return false;
 	}
 
+	protected void ForceAwardSolveToNickName(string nickname)
+	{
+		_delegatedSolveUserNickName = nickname;
+	}
+
 	protected void PrepareSilentSolve()
 	{
 		_delegatedSolveUserNickName = null;

--- a/TwitchPlaysAssembly/Src/ComponentSolvers/Helpers/ComponentSolverFactory.cs
+++ b/TwitchPlaysAssembly/Src/ComponentSolvers/Helpers/ComponentSolverFactory.cs
@@ -32,6 +32,7 @@ public static class ComponentSolverFactory
 
 		//AT_Bash Modules
 		ModComponentSolverCreators["MotionSense"] = module => new MotionSenseComponentSolver(module);
+		ModComponentSolverCreators["AppreciateArt"] = Module => new AppreciateArtComponentSolver(Module);
 
 		//Perky Modules
 		ModComponentSolverCreators["CrazyTalk"] = module => new CrazyTalkComponentSolver(module);
@@ -180,6 +181,7 @@ public static class ComponentSolverFactory
 
 		//AT_Bash / Bashly / Ashthebash
 		ModComponentSolverInformation["MotionSense"] = new ModuleInformation { builtIntoTwitchPlays = true, moduleDisplayName = "Motion Sense" };
+		ModComponentSolverInformation["AppreciateArt"] = new ModuleInformation { builtIntoTwitchPlays = true, unclaimable = true, moduleDisplayName = "Art Appreciation" };
 
 		//Perky
 		ModComponentSolverInformation["CrazyTalk"] = new ModuleInformation { builtIntoTwitchPlays = true, moduleDisplayName = "Crazy Talk", moduleScore = 3 };

--- a/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/AT_Bash/AppreciateArtComponentSolver.cs
+++ b/TwitchPlaysAssembly/Src/ComponentSolvers/Modded/AT_Bash/AppreciateArtComponentSolver.cs
@@ -1,0 +1,87 @@
+using System;
+using System.Collections;
+using System.Reflection;
+using UnityEngine;
+
+public class AppreciateArtComponentSolver : ComponentSolver
+{
+	private bool IsBeingZoomed = false;
+	private float? LocalStartTime = null;
+	private float LocalAppreciationReqTime = 60f;
+
+	public AppreciateArtComponentSolver(TwitchModule module) :
+		base(module)
+	{
+		ModInfo = ComponentSolverFactory.GetModuleInfo(GetModuleType(), "Zoom the module ('!{0} zoom 60') to appreciate the art.");
+		module.StartCoroutine(HandleInteraction());
+	}
+
+	protected internal override IEnumerator RespondToCommandInternal(string inputCommand)
+	{
+		// No valid commands.
+		yield break;
+	}
+
+	protected internal void ZoomStarted(string byUser)
+	{
+		IsBeingZoomed = true;
+		ForceAwardSolveToNickName(byUser);
+	}
+
+	protected internal void ZoomEnded()
+	{
+		IsBeingZoomed = false;
+	}
+
+	private IEnumerator HandleInteraction()
+	{
+		// We set _solved to true, which stops the module's own interactions.
+		SolvedField.SetValue(Module.BombComponent.GetComponent(ComponentType), true);
+		LocalAppreciationReqTime = (float)AppreciationTimeRequiredField.GetValue(Module.BombComponent.GetComponent(ComponentType));
+
+		while (true)
+		{
+			if (IsBeingZoomed)
+			{
+				// Camera is zoomed, appreciate
+				if (!LocalStartTime.HasValue)
+				{
+					// Just started appreciating
+					StartAppreciateMethod.Invoke(Module.BombComponent.GetComponent(ComponentType), null);
+					LocalStartTime = Time.time;
+				}
+				else if (Time.time - LocalStartTime >= LocalAppreciationReqTime)
+				{
+					// Appreciation time sufficient
+					EnlightenMethod.Invoke(Module.BombComponent.GetComponent(ComponentType), null);
+					yield break;
+				}
+			}
+			else if (LocalStartTime.HasValue)
+			{
+				// Not enough appreciation and zoom has ended
+				StopAppreciateMethod.Invoke(Module.BombComponent.GetComponent(ComponentType), null);
+				LocalStartTime = null;
+			}
+
+			yield return null;
+		}
+	}
+
+	static AppreciateArtComponentSolver()
+	{
+		ComponentType = ReflectionHelper.FindType("AppreciateArtModule");
+		SolvedField = ComponentType.GetField("_solved", BindingFlags.NonPublic | BindingFlags.Instance);
+		AppreciationTimeRequiredField = ComponentType.GetField("_appreciationRequiredDuration", BindingFlags.NonPublic | BindingFlags.Instance);
+		StartAppreciateMethod = ComponentType.GetMethod("StartAppreciatingArt", BindingFlags.NonPublic | BindingFlags.Instance);
+		StopAppreciateMethod = ComponentType.GetMethod("StopAppreciatingArt", BindingFlags.NonPublic | BindingFlags.Instance);
+		EnlightenMethod = ComponentType.GetMethod("Enlighten", BindingFlags.NonPublic | BindingFlags.Instance);
+	}
+
+	private static readonly Type ComponentType;
+	private static readonly FieldInfo SolvedField;
+	private static readonly FieldInfo AppreciationTimeRequiredField;
+	private static readonly MethodInfo StartAppreciateMethod;
+	private static readonly MethodInfo StopAppreciateMethod;
+	private static readonly MethodInfo EnlightenMethod;
+}

--- a/TwitchPlaysAssembly/TwitchPlaysAssembly.csproj
+++ b/TwitchPlaysAssembly/TwitchPlaysAssembly.csproj
@@ -151,6 +151,7 @@
     <Compile Include="Src\ComponentSolvers\Modded\Asimir\ShapeShiftComponentSolver.cs" />
     <Compile Include="Src\ComponentSolvers\Modded\Asimir\ThirdBaseComponentSolver.cs" />
     <Compile Include="Src\ComponentSolvers\Modded\AT_Bash\MotionSenseCompoenentSolver.cs" />
+    <Compile Include="Src\ComponentSolvers\Modded\AT_Bash\AppreciateArtComponentSolver.cs" />
     <Compile Include="Src\ComponentSolvers\Modded\External\CoroutineModComponentSolver.cs" />
     <Compile Include="Src\ComponentSolvers\Modded\External\SimpleModComponentSolver.cs" />
     <Compile Include="Src\ComponentSolvers\Modded\External\UnsupportedModComponentSolver.cs" />


### PR DESCRIPTION
To keep the spirit of the original module in Twitch Plays, the module gets solved by zooming it for a long enough period of time. The solve is credited to the person who gave the "zoom" command. (As such, the module is unclaimable, because anybody can zoom.)

Note that this required slight modification to the zoom command to detect an attempt to zoom Art Appreciation and handle it properly. If you've got any better ideas about how to handle behavior like this, I'm all ears.