### PR TITLE
Read bomb reward bonuses from spreadsheet

### DIFF
--- a/TwitchPlaysAssembly/Src/ComponentSolvers/ComponentSolver.cs
+++ b/TwitchPlaysAssembly/Src/ComponentSolvers/ComponentSolver.cs
@@ -709,6 +709,7 @@ public abstract class ComponentSolver
 				if (_delegatedAwardUserNickName != null)
 					AwardPoints(_delegatedAwardUserNickName, _pointsToAward);
 				AwardSolve(solverNickname, moduleScore);
+				AwardRewardBonus();
 			}
 			Module?.OnPass(solverNickname);
 		}
@@ -1026,12 +1027,6 @@ public abstract class ComponentSolver
 		}
 
 		IRCConnection.SendMessage(messageParts.Join());
-
-		if (ModInfo.moduleID == "organizationModule")
-		{
-			TwitchPlaySettings.AddRewardBonus((Module.Bomb.bombSolvableModules - 1) * 3);
-			IRCConnection.SendMessage($"Reward increased by {(Module.Bomb.bombSolvableModules - 1) * 3} for defusing module !{Code} ({ModInfo.moduleDisplayName}).");
-		}
 	}
 
 	private void AwardStrikes(int strikeCount) => AwardStrikes(null, strikeCount);
@@ -1188,6 +1183,28 @@ public abstract class ComponentSolver
 		}
 
 		IRCConnection.SendMessage(messageParts.Join());
+	}
+
+	internal void AwardRewardBonus()
+	{
+		int rewardBonus = 0;
+		switch(ModInfo.rewardBonusMethod)
+		{
+			case RewardBonusMethod.Fixed:
+				rewardBonus = (int)ModInfo.rewardBonus;
+				break;
+			case RewardBonusMethod.Dynamic:
+				rewardBonus = (int)(ModInfo.rewardBonus * Module.Bomb.bombSolvableModules);
+				break;
+			default:
+				break;
+		}
+
+		if (rewardBonus != 0)
+		{
+			TwitchPlaySettings.AddRewardBonus(rewardBonus);
+			IRCConnection.SendMessage($"Reward increased by {rewardBonus} for defusing module !{Code} ({ModInfo.moduleDisplayName}).");
+		}
 	}
 
 	protected void ReleaseHeldButtons()

--- a/TwitchPlaysAssembly/Src/ModuleData.cs
+++ b/TwitchPlaysAssembly/Src/ModuleData.cs
@@ -18,6 +18,9 @@ public class ModuleInformation
 
 	public ScoreMethod scoreMethod;
 
+	public float rewardBonus;
+	public RewardBonusMethod rewardBonusMethod;
+
 	public bool helpTextOverride;
 	public string helpText;
 
@@ -46,6 +49,8 @@ public class ModuleInformation
 	public bool ShouldSerializeDoesTheRightThing() => !builtIntoTwitchPlays;
 	public bool ShouldSerializevalidCommandsOverride() => !builtIntoTwitchPlays;
 	public bool ShouldSerializeScoreString() => false;
+	public bool ShouldSerializerewardBonus() => false;
+	public bool ShouldSerializerewardBonusMethod() => false;
 
 	public ModuleInformation Clone() => (ModuleInformation) MemberwiseClone();
 
@@ -90,6 +95,13 @@ public enum ScoreMethod
 	Default,
 	NeedyTime,
 	NeedySolves,
+}
+
+public enum RewardBonusMethod
+{
+	None,
+	Fixed,
+	Dynamic,
 }
 
 public enum StatusLightPosition

--- a/TwitchPlaysAssembly/Src/UI/TwitchModule.cs
+++ b/TwitchPlaysAssembly/Src/UI/TwitchModule.cs
@@ -324,26 +324,30 @@ public class TwitchModule : MonoBehaviour
 		float lastTime = Time.time;
 		while (true)
 		{
-			if (Claimed)
+			switch (needyModule.State)
 			{
-				switch (needyModule.State)
-				{
-					case NeedyStateEnum.BombComplete:
-					case NeedyStateEnum.Terminated:
-						yield break;
-					case NeedyStateEnum.Cooldown when lastState == NeedyStateEnum.Running:
+				case NeedyStateEnum.BombComplete:
+				case NeedyStateEnum.Terminated:
+					yield break;
+				case NeedyStateEnum.Cooldown when lastState == NeedyStateEnum.Running:
+					if (Claimed)
+					{
 						if (!PlayerNeedyStats.ContainsKey(PlayerName))
 							PlayerNeedyStats[PlayerName] = new NeedyStats();
 
 						PlayerNeedyStats[PlayerName].Solves++;
-						break;
-					case NeedyStateEnum.Running:
+					}
+					Solver.AwardRewardBonus();
+					break;
+				case NeedyStateEnum.Running:
+					if (Claimed)
+					{
 						if (!PlayerNeedyStats.ContainsKey(PlayerName))
 							PlayerNeedyStats[PlayerName] = new NeedyStats();
 
 						PlayerNeedyStats[PlayerName].ActiveTime += Time.time - lastTime;
-						break;
-				}
+					}
+					break;
 			}
 
 			lastState = needyModule.State;


### PR DESCRIPTION
Reward bonuses are read from the spreadsheet, either a fixed amount or based on number of modules, awarded on module solve (once) or needy deactivation (every time).

Removes the hardcoded reward bonus for Organization.